### PR TITLE
Add methods to get, set, and remove an object's parent(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-.idea
-*-build-*
-build*
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+*-build-*
+build*
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,11 @@ add_definitions(-DNON_MATLAB_PARSING)
 add_definitions(-DMAX_EXT_API_CONNECTIONS=255)
 add_definitions(-DDO_NOT_USE_SHARED_MEMORY)
 
+set(COPPELIA_SIM_CODE_LOCATION "coppeliarobotics" CACHE STRING "The path (absolute or relative) to the coppeliaSim code directory")
+
 INCLUDE_DIRECTORIES(${PROJECT_NAME} include)
-INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/remoteApi)
-INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/include)
+INCLUDE_DIRECTORIES(${PROJECT_NAME} ${COPPELIA_SIM_CODE_LOCATION}/remoteApi)
+INCLUDE_DIRECTORIES(${PROJECT_NAME} ${COPPELIA_SIM_CODE_LOCATION}/include)
 
 ################################################################
 # DEFINE AND INSTALL LIBRARY AND INCLUDE FOLDER
@@ -39,8 +41,8 @@ ADD_LIBRARY(${PROJECT_NAME} SHARED
     src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
     src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
     src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
-    coppeliarobotics/remoteApi/extApi.c
-    coppeliarobotics/remoteApi/extApiPlatform.c
+    ${COPPELIA_SIM_CODE_LOCATION}/remoteApi/extApi.c
+    ${COPPELIA_SIM_CODE_LOCATION}/remoteApi/extApiPlatform.c
     )
 
 SET_TARGET_PROPERTIES(${PROJECT_NAME} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,9 @@ add_definitions(-DNON_MATLAB_PARSING)
 add_definitions(-DMAX_EXT_API_CONNECTIONS=255)
 add_definitions(-DDO_NOT_USE_SHARED_MEMORY)
 
-set(COPPELIA_SIM_CODE_LOCATION "coppeliarobotics" CACHE STRING "The path (absolute or relative) to the coppeliaSim code directory")
-
 INCLUDE_DIRECTORIES(${PROJECT_NAME} include)
-INCLUDE_DIRECTORIES(${PROJECT_NAME} ${COPPELIA_SIM_CODE_LOCATION}/remoteApi)
-INCLUDE_DIRECTORIES(${PROJECT_NAME} ${COPPELIA_SIM_CODE_LOCATION}/include)
+INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/remoteApi)
+INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/include)
 
 ################################################################
 # DEFINE AND INSTALL LIBRARY AND INCLUDE FOLDER
@@ -41,8 +39,8 @@ ADD_LIBRARY(${PROJECT_NAME} SHARED
     src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
     src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
     src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
-    ${COPPELIA_SIM_CODE_LOCATION}/remoteApi/extApi.c
-    ${COPPELIA_SIM_CODE_LOCATION}/remoteApi/extApiPlatform.c
+    coppeliarobotics/remoteApi/extApi.c
+    coppeliarobotics/remoteApi/extApiPlatform.c
     )
 
 SET_TARGET_PROPERTIES(${PROJECT_NAME} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,15 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 PROJECT(dqrobotics-interface-vrep)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 17)
+
+option(WITH_PCL_OPTIMIZATION_FLAGS "Use optimization flags used by PCL to compile a compatible interface to EIGEN types" ON)
+set(PCL_OPTIMIZATION_FLAGS)
+if (${WITH_PCL_OPTIMIZATION_FLAGS})
+    find_package(PCL REQUIRED COMPONENTS common)
+    get_target_property(OUTPUT pcl_common INTERFACE_COMPILE_OPTIONS)
+    set(PCL_OPTIMIZATION_FLAGS ${OUTPUT})
+    message(STATUS "PCL optimization flags = ${PCL_OPTIMIZATION_FLAGS}")
+endif ()
 
 if(APPLE)
     INCLUDE_DIRECTORIES(
@@ -58,6 +67,8 @@ if(APPLE)
     TARGET_LINK_LIBRARIES(${PROJECT_NAME}
         -ldqrobotics)
 endif()
+
+target_compile_options(${PROJECT_NAME} PUBLIC ${PCL_OPTIMIZATION_FLAGS})
 
 ################################################################
 # INSTALL HEADERS IN SUBFOLDERS

--- a/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
+++ b/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
@@ -35,10 +35,6 @@ Contributors:
 
 const std::string VREP_OBJECTNAME_ABSOLUTE("VREP_OBJECTNAME_ABSOLUTE");
 
-using namespace DQ_robotics;
-using namespace Eigen;
-
-
 
 class DQ_VrepInterface
 {
@@ -94,45 +90,45 @@ public:
     std::vector<int> get_object_handles(const std::vector<std::string>& objectnames);
 
 
-    DQ   get_object_translation(const int& handle, const int& relative_to_handle, const OP_MODES& opmode);
-    DQ   get_object_translation(const int& handle, const std::string& relative_to_objectname, const OP_MODES& opmode);
-    DQ   get_object_translation(const std::string& objectname, const int& relative_to_handle, const OP_MODES& opmode);
-    DQ   get_object_translation(const std::string& objectname, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_AUTOMATIC);
+    DQ_robotics::DQ   get_object_translation(const int& handle, const int& relative_to_handle, const OP_MODES& opmode);
+    DQ_robotics::DQ   get_object_translation(const int& handle, const std::string& relative_to_objectname, const OP_MODES& opmode);
+    DQ_robotics::DQ   get_object_translation(const std::string& objectname, const int& relative_to_handle, const OP_MODES& opmode);
+    DQ_robotics::DQ   get_object_translation(const std::string& objectname, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_AUTOMATIC);
 
 
-    void set_object_translation(const int& handle, const int& relative_to_handle, const DQ& t, const OP_MODES& opmode) const;
-    void set_object_translation(const int& handle, const std::string& relative_to_objectname, const DQ& t, const OP_MODES& opmode);
-    void set_object_translation(const std::string& objectname, const int& relative_to_handle, const DQ& t, const OP_MODES& opmode);
-    void set_object_translation(const std::string& objectname, const DQ& t, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_ONESHOT);
+    void set_object_translation(const int& handle, const int& relative_to_handle, const DQ_robotics::DQ& t, const OP_MODES& opmode) const;
+    void set_object_translation(const int& handle, const std::string& relative_to_objectname, const DQ_robotics::DQ& t, const OP_MODES& opmode);
+    void set_object_translation(const std::string& objectname, const int& relative_to_handle, const DQ_robotics::DQ& t, const OP_MODES& opmode);
+    void set_object_translation(const std::string& objectname, const DQ_robotics::DQ& t, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_ONESHOT);
 
 
-    DQ   get_object_rotation(const int& handle, const int& relative_to_handle, const OP_MODES& opmode);
-    DQ   get_object_rotation(const int& handle, const std::string& relative_to_objectname, const OP_MODES& opmode);
-    DQ   get_object_rotation(const std::string& objectname, const int& relative_to_handle, const OP_MODES& opmode);
-    DQ   get_object_rotation(const std::string& objectname, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_AUTOMATIC);
+    DQ_robotics::DQ   get_object_rotation(const int& handle, const int& relative_to_handle, const OP_MODES& opmode);
+    DQ_robotics::DQ   get_object_rotation(const int& handle, const std::string& relative_to_objectname, const OP_MODES& opmode);
+    DQ_robotics::DQ   get_object_rotation(const std::string& objectname, const int& relative_to_handle, const OP_MODES& opmode);
+    DQ_robotics::DQ   get_object_rotation(const std::string& objectname, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_AUTOMATIC);
 
 
-    void set_object_rotation(const int& handle, const int& relative_to_handle, const DQ& r, const OP_MODES& opmode) const;
-    void set_object_rotation(const int& handle, const std::string& relative_to_objectname, const DQ& r, const OP_MODES& opmode);
-    void set_object_rotation(const std::string& objectname, const int& relative_to_handle, const DQ& r, const OP_MODES& opmode);
-    void set_object_rotation(const std::string& objectname, const DQ& r, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_ONESHOT);
+    void set_object_rotation(const int& handle, const int& relative_to_handle, const DQ_robotics::DQ& r, const OP_MODES& opmode) const;
+    void set_object_rotation(const int& handle, const std::string& relative_to_objectname, const DQ_robotics::DQ& r, const OP_MODES& opmode);
+    void set_object_rotation(const std::string& objectname, const int& relative_to_handle, const DQ_robotics::DQ& r, const OP_MODES& opmode);
+    void set_object_rotation(const std::string& objectname, const DQ_robotics::DQ& r, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_ONESHOT);
 
 
-    DQ get_object_pose(const int& handle, const int& relative_to_handle, const OP_MODES& opmode);
-    DQ get_object_pose(const int& handle, const std::string& relative_to_objectname, const OP_MODES& opmode);
-    DQ get_object_pose(const std::string& objectname, const int& relative_to_handle, const OP_MODES& opmode);
-    DQ get_object_pose(const std::string& objectname, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_AUTOMATIC);
+    DQ_robotics::DQ get_object_pose(const int& handle, const int& relative_to_handle, const OP_MODES& opmode);
+    DQ_robotics::DQ get_object_pose(const int& handle, const std::string& relative_to_objectname, const OP_MODES& opmode);
+    DQ_robotics::DQ get_object_pose(const std::string& objectname, const int& relative_to_handle, const OP_MODES& opmode);
+    DQ_robotics::DQ get_object_pose(const std::string& objectname, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_AUTOMATIC);
 
 
-    void set_object_pose(const int& handle, const int& relative_to_handle, const DQ& h, const OP_MODES& opmode) const;
-    void set_object_pose(const int& handle, const std::string& relative_to_objectname, const DQ& h, const OP_MODES& opmode);
-    void set_object_pose(const std::string& objectname, const int& relative_to_handle, const DQ& h, const OP_MODES& opmode);
-    void set_object_pose(const std::string& objectname, const DQ& h, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_ONESHOT);
+    void set_object_pose(const int& handle, const int& relative_to_handle, const DQ_robotics::DQ& h, const OP_MODES& opmode) const;
+    void set_object_pose(const int& handle, const std::string& relative_to_objectname, const DQ_robotics::DQ& h, const OP_MODES& opmode);
+    void set_object_pose(const std::string& objectname, const int& relative_to_handle, const DQ_robotics::DQ& h, const OP_MODES& opmode);
+    void set_object_pose(const std::string& objectname, const DQ_robotics::DQ& h, const std::string& relative_to_objectname=VREP_OBJECTNAME_ABSOLUTE, const OP_MODES& opmode=OP_ONESHOT);
 
 
-    std::vector<DQ> get_object_poses(const std::vector<int>& handles, const int& relative_to_handle, const OP_MODES& opmode);
+    std::vector<DQ_robotics::DQ> get_object_poses(const std::vector<int>& handles, const int& relative_to_handle, const OP_MODES& opmode);
 
-    void     set_object_poses(const std::vector<int>& handles, const int& relative_to_handle, const std::vector<DQ>& hs, const OP_MODES& opmode) const;
+    void     set_object_poses(const std::vector<int>& handles, const int& relative_to_handle, const std::vector<DQ_robotics::DQ>& hs, const OP_MODES& opmode) const;
 
     double   get_joint_position(const int& handle, const OP_MODES& opmode) const;
     double   get_joint_position(const std::string& jointname, const OP_MODES& opmode=OP_AUTOMATIC);
@@ -143,15 +139,15 @@ public:
     void     set_joint_target_position(const int& handle, const double& angle_rad, const OP_MODES& opmode) const;
     void     set_joint_target_position(const std::string& jointname, const double& angle_rad, const OP_MODES& opmode=OP_ONESHOT);
 
-    VectorXd get_joint_positions(const std::vector<int>& handles, const OP_MODES& opmode) const;
-    VectorXd get_joint_positions(const std::vector<std::string>& jointnames, const OP_MODES& opmode=OP_AUTOMATIC);
+    Eigen::VectorXd get_joint_positions(const std::vector<int>& handles, const OP_MODES& opmode) const;
+    Eigen::VectorXd get_joint_positions(const std::vector<std::string>& jointnames, const OP_MODES& opmode=OP_AUTOMATIC);
 
-    void     set_joint_positions(const std::vector<int>& handles, const VectorXd& angles_rad, const OP_MODES& opmode) const;
-    void     set_joint_positions(const std::vector<std::string>& jointnames, const VectorXd& angles_rad, const OP_MODES& opmode=OP_ONESHOT);
+    void     set_joint_positions(const std::vector<int>& handles, const Eigen::VectorXd& angles_rad, const OP_MODES& opmode) const;
+    void     set_joint_positions(const std::vector<std::string>& jointnames, const Eigen::VectorXd& angles_rad, const OP_MODES& opmode=OP_ONESHOT);
 
 
-    void     set_joint_target_positions(const std::vector<int>& handles, const VectorXd& angles_rad, const OP_MODES& opmode) const;
-    void     set_joint_target_positions(const std::vector<std::string>& jointnames, const VectorXd& angles_rad, const OP_MODES& opmode=OP_ONESHOT);
+    void     set_joint_target_positions(const std::vector<int>& handles, const Eigen::VectorXd& angles_rad, const OP_MODES& opmode) const;
+    void     set_joint_target_positions(const std::vector<std::string>& jointnames, const Eigen::VectorXd& angles_rad, const OP_MODES& opmode=OP_ONESHOT);
 
     void start_video_recording();
     void stop_video_recording();
@@ -160,29 +156,29 @@ public:
     //--New ones------
     void     set_joint_target_velocity(const int& handle, const double& angle_dot_rad, const OP_MODES& opmode) const;
     void     set_joint_target_velocity(const std::string& jointname, const double& angle_dot_rad, const OP_MODES& opmode=OP_ONESHOT);
-    void     set_joint_target_velocities(const std::vector<int>& handles, const VectorXd& angles_dot_rad, const OP_MODES& opmode) const;
-    void     set_joint_target_velocities(const std::vector<std::string>& jointnames, const VectorXd& angles_dot_rad, const OP_MODES& opmode=OP_ONESHOT);
+    void     set_joint_target_velocities(const std::vector<int>& handles, const Eigen::VectorXd& angles_dot_rad, const OP_MODES& opmode) const;
+    void     set_joint_target_velocities(const std::vector<std::string>& jointnames, const Eigen::VectorXd& angles_dot_rad, const OP_MODES& opmode=OP_ONESHOT);
 
     double   get_joint_velocity(const int& handle, const OP_MODES& opmode) const;
     double   get_joint_velocity(const std::string& jointname, const OP_MODES& opmode=OP_AUTOMATIC);
-    VectorXd get_joint_velocities(const std::vector<int>& handles, const OP_MODES& opmode) const;
-    VectorXd get_joint_velocities(const std::vector<std::string>& jointnames, const OP_MODES& opmode=OP_AUTOMATIC);
+    Eigen::VectorXd get_joint_velocities(const std::vector<int>& handles, const OP_MODES& opmode) const;
+    Eigen::VectorXd get_joint_velocities(const std::vector<std::string>& jointnames, const OP_MODES& opmode=OP_AUTOMATIC);
 
     void     set_joint_torque(const int& handle, const double& torque, const OP_MODES& opmode) const;
     void     set_joint_torque(const std::string& jointname, const double& torque, const OP_MODES& opmode=OP_ONESHOT);
-    void     set_joint_torques(const std::vector<int>& handles, const VectorXd& torques, const OP_MODES& opmode) const;
-    void     set_joint_torques(const std::vector<std::string>& jointnames, const VectorXd& torques, const OP_MODES& opmode=OP_ONESHOT);
+    void     set_joint_torques(const std::vector<int>& handles, const Eigen::VectorXd& torques, const OP_MODES& opmode) const;
+    void     set_joint_torques(const std::vector<std::string>& jointnames, const Eigen::VectorXd& torques, const OP_MODES& opmode=OP_ONESHOT);
 
     double   get_joint_torque(const int& handle, const OP_MODES& opmode) const;
     double   get_joint_torque(const std::string& jointname, const OP_MODES& opmode=OP_AUTOMATIC);
-    VectorXd get_joint_torques(const std::vector<int>& handles, const OP_MODES& opmode) const;
-    VectorXd get_joint_torques(const std::vector<std::string>& jointnames, const OP_MODES& opmode=OP_AUTOMATIC);
+    Eigen::VectorXd get_joint_torques(const std::vector<int>& handles, const OP_MODES& opmode) const;
+    Eigen::VectorXd get_joint_torques(const std::vector<std::string>& jointnames, const OP_MODES& opmode=OP_AUTOMATIC);
 
-    MatrixXd get_inertia_matrix(const std::string& link_name, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_inertia", const std::string& obj_name= "DQRoboticsApiCommandServer");
-    MatrixXd get_inertia_matrix(const int& handle, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_inertia", const std::string& obj_name= "DQRoboticsApiCommandServer");
+    Eigen::MatrixXd get_inertia_matrix(const std::string& link_name, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_inertia", const std::string& obj_name= "DQRoboticsApiCommandServer");
+    Eigen::MatrixXd get_inertia_matrix(const int& handle, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_inertia", const std::string& obj_name= "DQRoboticsApiCommandServer");
 
-    DQ      get_center_of_mass(const std::string& link_name, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_center_of_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
-    DQ      get_center_of_mass(const int& handle, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_center_of_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
+    DQ_robotics::DQ      get_center_of_mass(const std::string& link_name, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_center_of_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
+    DQ_robotics::DQ      get_center_of_mass(const int& handle, const REFERENCE_FRAMES& reference_frame=BODY_FRAME, const std::string& function_name = "get_center_of_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
 
     double get_mass(const std::string& link_name, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
     double get_mass(const int& handle, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
@@ -198,7 +194,7 @@ public:
 
 
 private:
-    std::map<std::string,DQ_VrepInterfaceMapElement> name_to_element_map_;
+    std::map<std::string,DQ_robotics::DQ_VrepInterfaceMapElement> name_to_element_map_;
 
     int MAX_TRY_COUNT_;
     int TIMEOUT_IN_MILISECONDS_;
@@ -206,11 +202,11 @@ private:
     long int global_retry_count_;
     std::atomic_bool* no_blocking_loops_;
 
-    void _insert_or_update_map(const std::string& objectname, const DQ_VrepInterfaceMapElement& element);
+    void _insert_or_update_map(const std::string& objectname, const DQ_robotics::DQ_VrepInterfaceMapElement& element);
 
     int _get_handle_from_map(const std::string& objectname);
 
-    DQ_VrepInterfaceMapElement &_get_element_from_map(const std::string& objectname);
+    DQ_robotics::DQ_VrepInterfaceMapElement &_get_element_from_map(const std::string& objectname);
 
     int _call_script_function(const std::string&  function_name, const std::string&  obj_name, const std::vector<int>& input_ints, const std::vector<float>& input_floats, const std::vector<std::string> &input_strings,
                                 int* outIntCnt, int** output_ints, int* outFloatCnt, float** output_floats, int* outStringCnt, char** output_strings,

--- a/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
+++ b/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
@@ -187,19 +187,14 @@ public:
     double get_mass(const std::string& link_name, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
     double get_mass(const int& handle, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
 
-    int  getObjectParent(int objectHandle, OP_MODES const &opMode = OP_AUTOMATIC);
+    int  get_object_parent(int object_handle, const OP_MODES &op_mode = OP_AUTOMATIC);
+    int  get_object_parent(const std::string &object_name, const OP_MODES &op_mode = OP_AUTOMATIC);
 
-    int  getObjectParent(std::string const &objectName, OP_MODES const &opMode = OP_AUTOMATIC);
+    void set_object_parent(int object_handle, int parent_object_handle, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
+    void set_object_parent(const std::string &object_name, const std::string &parent_object_name, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
 
-    void setObjectParent(int objectHandle, int parentObjectHandle, bool keepInPlace,
-                         OP_MODES const &opMode = OP_AUTOMATIC);
-
-    void setObjectParent(std::string const &objectName, std::string const &parentObjectName, bool keepInPlace,
-                         OP_MODES const &opMode = OP_AUTOMATIC);
-
-    void removeObjectParents(int objectHandle, bool keepInPlace, OP_MODES const &opMode = OP_AUTOMATIC);
-
-    void removeObjectParents(std::string const &objectName, bool keepInPlace, OP_MODES const &opMode = OP_AUTOMATIC);
+    void remove_object_parents(int object_handle, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
+    void remove_object_parents(const std::string &object_name, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
 
 
 private:

--- a/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
+++ b/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
@@ -187,14 +187,14 @@ public:
     double get_mass(const std::string& link_name, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
     double get_mass(const int& handle, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
 
-    int  get_object_parent(int object_handle, const OP_MODES &op_mode = OP_AUTOMATIC);
-    int  get_object_parent(const std::string &object_name, const OP_MODES &op_mode = OP_AUTOMATIC);
+    int  get_object_parent(int object_handle);
+    int  get_object_parent(const std::string &object_name);
 
-    void set_object_parent(int object_handle, int parent_object_handle, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
-    void set_object_parent(const std::string &object_name, const std::string &parent_object_name, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
+    void set_object_parent(int object_handle, int parent_object_handle, bool keep_in_place, const OP_MODES &op_mode = OP_BLOCKING);
+    void set_object_parent(const std::string &object_name, const std::string &parent_object_name, bool keep_in_place, const OP_MODES &op_mode = OP_BLOCKING);
 
-    void remove_object_parents(int object_handle, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
-    void remove_object_parents(const std::string &object_name, bool keep_in_place, const OP_MODES &op_mode = OP_AUTOMATIC);
+    void remove_object_parents(int object_handle, bool keep_in_place, const OP_MODES &op_mode = OP_BLOCKING);
+    void remove_object_parents(const std::string &object_name, bool keep_in_place, const OP_MODES &op_mode = OP_BLOCKING);
 
 
 private:

--- a/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
+++ b/include/dqrobotics/interfaces/vrep/DQ_VrepInterface.h
@@ -187,6 +187,19 @@ public:
     double get_mass(const std::string& link_name, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
     double get_mass(const int& handle, const std::string& function_name = "get_mass", const std::string& obj_name= "DQRoboticsApiCommandServer");
 
+    int  getObjectParent(int objectHandle, OP_MODES const &opMode = OP_AUTOMATIC);
+
+    int  getObjectParent(std::string const &objectName, OP_MODES const &opMode = OP_AUTOMATIC);
+
+    void setObjectParent(int objectHandle, int parentObjectHandle, bool keepInPlace,
+                         OP_MODES const &opMode = OP_AUTOMATIC);
+
+    void setObjectParent(std::string const &objectName, std::string const &parentObjectName, bool keepInPlace,
+                         OP_MODES const &opMode = OP_AUTOMATIC);
+
+    void removeObjectParents(int objectHandle, bool keepInPlace, OP_MODES const &opMode = OP_AUTOMATIC);
+
+    void removeObjectParents(std::string const &objectName, bool keepInPlace, OP_MODES const &opMode = OP_AUTOMATIC);
 
 
 private:

--- a/include/dqrobotics/interfaces/vrep/DQ_VrepRobot.h
+++ b/include/dqrobotics/interfaces/vrep/DQ_VrepRobot.h
@@ -41,8 +41,8 @@ protected:
     DQ_VrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep_interface);
 public:
     virtual ~DQ_VrepRobot() = default;
-    virtual void send_q_to_vrep(const VectorXd& q) = 0;
-    virtual VectorXd get_q_from_vrep() = 0;
+    virtual void send_q_to_vrep(const Eigen::VectorXd& q) = 0;
+    virtual Eigen::VectorXd get_q_from_vrep() = 0;
 };
 }
 #endif

--- a/include/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.h
+++ b/include/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.h
@@ -37,9 +37,9 @@ private:
 public:
     LBR4pVrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep_interface);
 
-    void send_q_to_vrep(const VectorXd &q) override;
-    void send_q_target_to_vrep(const VectorXd& q_target);
-    VectorXd get_q_from_vrep() override;
+    void send_q_to_vrep(const Eigen::VectorXd &q) override;
+    void send_q_target_to_vrep(const Eigen::VectorXd& q_target);
+    Eigen::VectorXd get_q_from_vrep() override;
 
     DQ_SerialManipulatorDH kinematics();
 };

--- a/include/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.h
+++ b/include/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.h
@@ -39,8 +39,8 @@ private:
 public:
     YouBotVrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep_interface);
 
-    void send_q_to_vrep(const VectorXd &q) override;
-    VectorXd get_q_from_vrep() override;
+    void send_q_to_vrep(const Eigen::VectorXd &q) override;
+    Eigen::VectorXd get_q_from_vrep() override;
 
     DQ_SerialWholeBody kinematics();
 };

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -29,6 +29,9 @@ Contributors:
 #include<thread>
 #include<chrono>
 
+using namespace DQ_robotics;
+using namespace Eigen;
+
 ///****************************************************************************************
 ///                        PRIVATE FUNCTIONS
 /// ***************************************************************************************

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -1777,35 +1777,75 @@ double DQ_VrepInterface::get_mass(const std::string& link_name, const std::strin
     return get_mass(_get_handle_from_map(link_name), function_name,obj_name);
 }
 
-int DQ_VrepInterface::getObjectParent(int objectHandle, OP_MODES const &opMode) {
+/**
+ * @brief This method gets the parent of an object.
+ * @param object_handle The object handle.
+ * @param op_mode The operation mode.
+ */
+int DQ_VrepInterface::get_object_parent(int object_handle, const OP_MODES &op_mode) {
     int parentObjectHandle;
-    const std::function<simxInt(void)> f = std::bind(simxGetObjectParent, clientid_, objectHandle, &parentObjectHandle, opMode);
-    _retry_function(f,MAX_TRY_COUNT_,TIMEOUT_IN_MILISECONDS_,no_blocking_loops_,opMode);
+    const std::function<simxInt(void)> f = std::bind(simxGetObjectParent, clientid_, object_handle, &parentObjectHandle, op_mode);
+    _retry_function(f, MAX_TRY_COUNT_, TIMEOUT_IN_MILISECONDS_, no_blocking_loops_, op_mode);
     return parentObjectHandle;
 }
 
-int DQ_VrepInterface::getObjectParent(std::string const &objectName, OP_MODES const &opMode) {
-    return this->getObjectParent(_get_handle_from_map(objectName), opMode);
+/**
+ * @brief This method gets the parent of an object.
+ *        This acts as a convenience function for achieving the same functionality without having an object's handle
+ * @param object_name The object name.
+ * @param op_mode The operation mode.
+ */
+int DQ_VrepInterface::get_object_parent(const std::string &object_name, const OP_MODES &op_mode) {
+    return this->get_object_parent(_get_handle_from_map(object_name), op_mode);
 }
 
-void DQ_VrepInterface::setObjectParent(int objectHandle, int parentObjectHandle, bool keepInPlace,
-                                       OP_MODES const &opMode) {
-    const std::function<simxInt(void)> f = std::bind(simxSetObjectParent, clientid_, objectHandle, parentObjectHandle, keepInPlace, opMode);
-    _retry_function(f,MAX_TRY_COUNT_,TIMEOUT_IN_MILISECONDS_,no_blocking_loops_,opMode);
+/**
+ * @brief This method sets the parent of an object.
+ * @param object_handle The object handle.
+ * @param parent_object_handle The handle of the object that will become the parent of object_handle.
+ * @param keep_in_place if true, the object's pose will be interpreted relative to the global coordinate frame
+ *                      if false, the object's pose will be interpreted relative to the parent's coordinate frame
+ * @param op_mode The operation mode.
+ */
+void DQ_VrepInterface::set_object_parent(int object_handle, int parent_object_handle, bool keep_in_place, const OP_MODES &op_mode) {
+    const std::function<simxInt(void)> f = std::bind(simxSetObjectParent, clientid_, object_handle, parent_object_handle, keep_in_place, op_mode);
+    _retry_function(f, MAX_TRY_COUNT_, TIMEOUT_IN_MILISECONDS_, no_blocking_loops_, op_mode);
 }
 
-void DQ_VrepInterface::setObjectParent(std::string const &objectName, std::string const &parentObjectName,
-                                       bool keepInPlace, OP_MODES const &opMode) {
-    this->setObjectParent(_get_handle_from_map(objectName), _get_handle_from_map(parentObjectName), keepInPlace,
-                          opMode);
+/**
+ * @brief This method sets the parent of an object.
+ *        This acts as a convenience function for achieving the same functionality without having the objects' handle
+ * @param object_name The object name.
+ * @param parent_object_name The name of the object that will become the parent of object_name.
+ * @param keep_in_place if true, the object's pose will be interpreted relative to the global coordinate frame
+ *                      if false, the object's pose will be interpreted relative to the parent's coordinate frame
+ * @param op_mode The operation mode.
+ */
+void DQ_VrepInterface::set_object_parent(const std::string &object_name, const std::string &parent_object_name, bool keep_in_place, const OP_MODES &op_mode) {
+    this->set_object_parent(_get_handle_from_map(object_name), _get_handle_from_map(parent_object_name), keep_in_place, op_mode);
 }
 
-void DQ_VrepInterface::removeObjectParents(int objectHandle, bool keepInPlace, OP_MODES const &opMode) {
-    this->setObjectParent(objectHandle, -1, keepInPlace, opMode);
+/**
+ * @brief This method removes all parents of an object making the object part of the "global" scene hierarchy.
+ * @param object_handle The object handle.
+ * @param keep_in_place if true, the object's pose will be interpreted relative to the global coordinate frame
+ *                      if false, the object's pose will be interpreted relative to the parent's coordinate frame
+ * @param op_mode The operation mode.
+ */
+void DQ_VrepInterface::remove_object_parents(int object_handle, bool keep_in_place, const OP_MODES &op_mode) {
+    this->set_object_parent(object_handle, -1, keep_in_place, op_mode);
 }
 
-void DQ_VrepInterface::removeObjectParents(std::string const &objectName, bool keepInPlace, OP_MODES const &opMode) {
-    this->setObjectParent(_get_handle_from_map(objectName), -1, keepInPlace, opMode);
+/**
+ * @brief This method removes all parents of an object making the object part of the "global" scene hierarchy.
+ *        This acts as a convenience function for achieving the same functionality without having the object's handle
+ * @param object_name The object name.
+ * @param keep_in_place if true, the object's pose will be interpreted relative to the global coordinate frame
+ *                      if false, the object's pose will be interpreted relative to the parent's coordinate frame
+ * @param op_mode The operation mode.
+ */
+void DQ_VrepInterface::remove_object_parents(const std::string &object_name, bool keep_in_place, const OP_MODES &op_mode) {
+    this->set_object_parent(_get_handle_from_map(object_name), -1, keep_in_place, op_mode);
 }
 
 /**

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -1808,7 +1808,7 @@ int DQ_VrepInterface::get_object_parent(const std::string &object_name) {
  * @param op_mode The operation mode.
  */
 void DQ_VrepInterface::set_object_parent(int object_handle, int parent_object_handle, bool keep_in_place, const OP_MODES &op_mode) {
-    const std::function<simxInt(void)> f = std::bind(simxSetObjectParent, clientid_, object_handle, parent_object_handle, keep_in_place, op_mode);
+    const std::function<simxInt(void)> f = std::bind(simxSetObjectParent, clientid_, object_handle, parent_object_handle, keep_in_place, _remap_op_mode(op_mode));
     _retry_function(f, MAX_TRY_COUNT_, TIMEOUT_IN_MILISECONDS_, no_blocking_loops_, op_mode);
 }
 

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -1796,7 +1796,7 @@ int DQ_VrepInterface::get_object_parent(int object_handle, const OP_MODES &op_mo
  * @param op_mode The operation mode.
  */
 int DQ_VrepInterface::get_object_parent(const std::string &object_name, const OP_MODES &op_mode) {
-    return this->get_object_parent(_get_handle_from_map(object_name), op_mode);
+    return get_object_parent(_get_handle_from_map(object_name), op_mode);
 }
 
 /**
@@ -1822,7 +1822,7 @@ void DQ_VrepInterface::set_object_parent(int object_handle, int parent_object_ha
  * @param op_mode The operation mode.
  */
 void DQ_VrepInterface::set_object_parent(const std::string &object_name, const std::string &parent_object_name, bool keep_in_place, const OP_MODES &op_mode) {
-    this->set_object_parent(_get_handle_from_map(object_name), _get_handle_from_map(parent_object_name), keep_in_place, op_mode);
+    set_object_parent(_get_handle_from_map(object_name), _get_handle_from_map(parent_object_name), keep_in_place, op_mode);
 }
 
 /**
@@ -1833,7 +1833,7 @@ void DQ_VrepInterface::set_object_parent(const std::string &object_name, const s
  * @param op_mode The operation mode.
  */
 void DQ_VrepInterface::remove_object_parents(int object_handle, bool keep_in_place, const OP_MODES &op_mode) {
-    this->set_object_parent(object_handle, -1, keep_in_place, op_mode);
+    set_object_parent(object_handle, -1, keep_in_place, op_mode);
 }
 
 /**
@@ -1845,7 +1845,7 @@ void DQ_VrepInterface::remove_object_parents(int object_handle, bool keep_in_pla
  * @param op_mode The operation mode.
  */
 void DQ_VrepInterface::remove_object_parents(const std::string &object_name, bool keep_in_place, const OP_MODES &op_mode) {
-    this->set_object_parent(_get_handle_from_map(object_name), -1, keep_in_place, op_mode);
+    set_object_parent(_get_handle_from_map(object_name), -1, keep_in_place, op_mode);
 }
 
 /**

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -1782,10 +1782,10 @@ double DQ_VrepInterface::get_mass(const std::string& link_name, const std::strin
  * @param object_handle The object handle.
  * @param op_mode The operation mode.
  */
-int DQ_VrepInterface::get_object_parent(int object_handle, const OP_MODES &op_mode) {
+int DQ_VrepInterface::get_object_parent(int object_handle) {
     int parentObjectHandle;
-    const std::function<simxInt(void)> f = std::bind(simxGetObjectParent, clientid_, object_handle, &parentObjectHandle, op_mode);
-    _retry_function(f, MAX_TRY_COUNT_, TIMEOUT_IN_MILISECONDS_, no_blocking_loops_, op_mode);
+    const std::function<simxInt(void)> f = std::bind(simxGetObjectParent, clientid_, object_handle, &parentObjectHandle, simx_opmode_blocking);
+    _retry_function(f, MAX_TRY_COUNT_, TIMEOUT_IN_MILISECONDS_, no_blocking_loops_, OP_BLOCKING);
     return parentObjectHandle;
 }
 
@@ -1795,8 +1795,8 @@ int DQ_VrepInterface::get_object_parent(int object_handle, const OP_MODES &op_mo
  * @param object_name The object name.
  * @param op_mode The operation mode.
  */
-int DQ_VrepInterface::get_object_parent(const std::string &object_name, const OP_MODES &op_mode) {
-    return get_object_parent(_get_handle_from_map(object_name), op_mode);
+int DQ_VrepInterface::get_object_parent(const std::string &object_name) {
+    return get_object_parent(_get_handle_from_map(object_name));
 }
 
 /**

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -238,7 +238,7 @@ std::vector<std::string> _extract_vector_string_from_char_pointer(const char *st
  *
  */
 call_script_data _extract_call_script_data_from_pointers(int return_code, int outIntCnt, int* output_ints, int outFloatCnt, float* output_floats, int outStringCnt, char* output_strings)
-{    
+{
     struct call_script_data data;
     data.return_code = return_code;
 
@@ -1599,7 +1599,7 @@ MatrixXd DQ_VrepInterface::get_inertia_matrix(const int& handle, const REFERENCE
  *
  */
 MatrixXd DQ_VrepInterface::get_inertia_matrix(const std::string& link_name, const REFERENCE_FRAMES& reference_frame, const std::string& function_name, const std::string& obj_name)
-{    
+{
     return get_inertia_matrix(_get_handle_from_map(link_name), reference_frame, function_name, obj_name);
 }
 
@@ -1697,7 +1697,7 @@ DQ DQ_VrepInterface::get_center_of_mass(const int& handle,  const REFERENCE_FRAM
  *
  */
 DQ DQ_VrepInterface::get_center_of_mass(const std::string& link_name, const REFERENCE_FRAMES& reference_frame, const std::string& function_name, const std::string& obj_name)
-{    
+{
     return get_center_of_mass(_get_handle_from_map(link_name), reference_frame,function_name, obj_name);
 }
 
@@ -1775,6 +1775,37 @@ double DQ_VrepInterface::get_mass(const int& handle, const std::string& function
 double DQ_VrepInterface::get_mass(const std::string& link_name, const std::string& function_name, const std::string& obj_name)
 {
     return get_mass(_get_handle_from_map(link_name), function_name,obj_name);
+}
+
+int DQ_VrepInterface::getObjectParent(int objectHandle, OP_MODES const &opMode) {
+    int parentObjectHandle;
+    const std::function<simxInt(void)> f = std::bind(simxGetObjectParent, clientid_, objectHandle, &parentObjectHandle, opMode);
+    _retry_function(f,MAX_TRY_COUNT_,TIMEOUT_IN_MILISECONDS_,no_blocking_loops_,opMode);
+    return parentObjectHandle;
+}
+
+int DQ_VrepInterface::getObjectParent(std::string const &objectName, OP_MODES const &opMode) {
+    return this->getObjectParent(_get_handle_from_map(objectName), opMode);
+}
+
+void DQ_VrepInterface::setObjectParent(int objectHandle, int parentObjectHandle, bool keepInPlace,
+                                       OP_MODES const &opMode) {
+    const std::function<simxInt(void)> f = std::bind(simxSetObjectParent, clientid_, objectHandle, parentObjectHandle, keepInPlace, opMode);
+    _retry_function(f,MAX_TRY_COUNT_,TIMEOUT_IN_MILISECONDS_,no_blocking_loops_,opMode);
+}
+
+void DQ_VrepInterface::setObjectParent(std::string const &objectName, std::string const &parentObjectName,
+                                       bool keepInPlace, OP_MODES const &opMode) {
+    this->setObjectParent(_get_handle_from_map(objectName), _get_handle_from_map(parentObjectName), keepInPlace,
+                          opMode);
+}
+
+void DQ_VrepInterface::removeObjectParents(int objectHandle, bool keepInPlace, OP_MODES const &opMode) {
+    this->setObjectParent(objectHandle, -1, keepInPlace, opMode);
+}
+
+void DQ_VrepInterface::removeObjectParents(std::string const &objectName, bool keepInPlace, OP_MODES const &opMode) {
+    this->setObjectParent(_get_handle_from_map(objectName), -1, keepInPlace, opMode);
 }
 
 /**

--- a/src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
@@ -23,6 +23,8 @@ Contributors:
 #include<dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.h>
 #include<dqrobotics/utils/DQ_Constants.h>
 
+using namespace Eigen;
+
 namespace DQ_robotics
 {
 

--- a/src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
@@ -27,6 +27,8 @@ Contributors:
 #include<dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.h>
 #include<dqrobotics/utils/DQ_Constants.h>
 
+using namespace Eigen;
+
 namespace DQ_robotics
 {
 


### PR DESCRIPTION
The main aim is to grasp and release objects with robots from C++ code. 
In addition, the functionality of the added functions can be extended to more than that: Creating complex scenes programmatically, by arranging objects on other objects or connecting objects and part of scenes together, which is why setting a parent object of another is desirable and thus implemented in this feature.