### PR TITLE
This PR adds support for smart pointers

### DIFF
--- a/include/dqrobotics/interfaces/vrep/DQ_VrepRobot.h
+++ b/include/dqrobotics/interfaces/vrep/DQ_VrepRobot.h
@@ -1,30 +1,27 @@
 /**
-(C) Copyright 2019 DQ Robotics Developers
-
+(C) Copyright 2019-2023 DQ Robotics Developers
 This file is part of DQ Robotics.
-
     DQ Robotics is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-
     DQ Robotics is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-
     You should have received a copy of the GNU Lesser General Public License
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
-
 Contributors:
 - Murilo M. Marinho        (murilo@nml.t.u-tokyo.ac.jp)
+        - Responsible for the original implementation.
+- Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+        - Added smart pointers, deprecated raw pointers. 
+         (Adapted from DQ_PseudoinverseController.h and DQ_KinematicController.h)
 */
 
-#ifndef DQ_ROBOTICS_VREP_ROBOT_HEADER_GUARD
-#define DQ_ROBOTICS_VREP_ROBOT_HEADER_GUARD
-
+#pragma once
 #include<string>
-
+#include<memory>
 #include<dqrobotics/robot_modeling/DQ_Kinematics.h>
 #include<dqrobotics/interfaces/vrep/DQ_VrepInterface.h>
 namespace DQ_robotics
@@ -37,13 +34,19 @@ protected:
     std::string robot_name_;
     //Just an observing pointer, we do not take or share ownership (As implied by the raw pointer)
     DQ_VrepInterface* vrep_interface_;
+    std::shared_ptr<DQ_VrepInterface> vrep_interface_sptr_;
+
+    //For backwards compatibility reasons, to be removed
+    DQ_VrepInterface* _get_interface_ptr() const;
+    std::shared_ptr<DQ_VrepInterface> _get_interface_sptr() const;
 
     DQ_VrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep_interface);
+    DQ_VrepRobot(const std::string& robot_name, const std::shared_ptr<DQ_VrepInterface>& vrep_interface_sptr);
 public:
     virtual ~DQ_VrepRobot() = default;
     virtual void send_q_to_vrep(const VectorXd& q) = 0;
     virtual VectorXd get_q_from_vrep() = 0;
 };
 }
-#endif
+
 

--- a/include/dqrobotics/interfaces/vrep/DQ_VrepRobot.h
+++ b/include/dqrobotics/interfaces/vrep/DQ_VrepRobot.h
@@ -1,19 +1,25 @@
 /**
 (C) Copyright 2019-2023 DQ Robotics Developers
+
 This file is part of DQ Robotics.
+
     DQ Robotics is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
+
     DQ Robotics is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
+
     You should have received a copy of the GNU Lesser General Public License
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
 Contributors:
 - Murilo M. Marinho        (murilo@nml.t.u-tokyo.ac.jp)
         - Responsible for the original implementation.
+        
 - Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
         - Added smart pointers, deprecated raw pointers. 
          (Adapted from DQ_PseudoinverseController.h and DQ_KinematicController.h)

--- a/include/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.h
+++ b/include/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.h
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2019 DQ Robotics Developers
+(C) Copyright 2019-2023 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -18,11 +18,14 @@ This file is part of DQ Robotics.
 
 Contributors:
 - Murilo M. Marinho        (murilo@nml.t.u-tokyo.ac.jp)
+        - Responsible for the original implementation.
+        
+- Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+        - Added smart pointers, deprecated raw pointers. 
+         (Adapted from DQ_PseudoinverseController.h and DQ_KinematicController.h)
 */
 
-#ifndef DQ_ROBOTICS_LBR4P_VREP_ROBOT_HEADER_GUARD
-#define DQ_ROBOTICS_LBR4P_VREP_ROBOT_HEADER_GUARD
-
+#pragma once
 #include <vector>
 #include <dqrobotics/interfaces/vrep/DQ_VrepRobot.h>
 #include <dqrobotics/robot_modeling/DQ_SerialManipulatorDH.h>
@@ -34,8 +37,11 @@ class LBR4pVrepRobot: public DQ_VrepRobot
 private:
     std::vector<std::string> joint_names_;
     std::string base_frame_name_;
+    void _set_names(const std::string& robot_name);
 public:
+    [[deprecated("Use the smart pointer version instead")]]
     LBR4pVrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep_interface);
+    LBR4pVrepRobot(const std::string& robot_name, const std::shared_ptr<DQ_VrepInterface>& vrep_interface_sptr);
 
     void send_q_to_vrep(const VectorXd &q) override;
     void send_q_target_to_vrep(const VectorXd& q_target);
@@ -46,4 +52,4 @@ public:
 }
 
 
-#endif
+

--- a/include/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.h
+++ b/include/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.h
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2019 DQ Robotics Developers
+(C) Copyright 2019-2023 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 
@@ -18,11 +18,15 @@ This file is part of DQ Robotics.
 
 Contributors:
 - Murilo M. Marinho        (murilo@nml.t.u-tokyo.ac.jp)
+        - Responsible for the original implementation.
+        
+- Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+        - Added smart pointers, deprecated raw pointers. 
+         (Adapted from DQ_PseudoinverseController.h and DQ_KinematicController.h)
 */
 
-#ifndef DQ_ROBOTICS_YOUBOT_VREP_ROBOT_HEADER_GUARD
-#define DQ_ROBOTICS_YOUBOT_VREP_ROBOT_HEADER_GUARD
-
+#pragma once
+#include <memory>
 #include <string>
 #include <vector>
 #include <dqrobotics/interfaces/vrep/DQ_VrepRobot.h>
@@ -36,8 +40,11 @@ private:
     std::vector<std::string> joint_names_;
     std::string base_frame_name_;
     DQ adjust_;
+    void _set_names(const std::string& robot_name);
 public:
+    [[deprecated("Use the smart pointer version instead")]]
     YouBotVrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep_interface);
+    YouBotVrepRobot(const std::string& robot_name, const std::shared_ptr<DQ_VrepInterface>& vrep_interface_sptr);
 
     void send_q_to_vrep(const VectorXd &q) override;
     VectorXd get_q_from_vrep() override;
@@ -47,4 +54,4 @@ public:
 }
 
 
-#endif
+

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
@@ -59,8 +59,10 @@ DQ_VrepRobot::DQ_VrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep
     vrep_interface_ = vrep_interface;
 }
 
+
 /**
- * @brief Constructor of the class.
+ * @brief Construct a DQ_VrepRobot::DQ_VrepRobot object
+ * 
  * @param robot_name The name of robot used on the vrep scene.
  * @param vrep_interface_sptr The DQ_VrepInterface smart pointer.
  */

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
@@ -61,7 +61,7 @@ DQ_VrepRobot::DQ_VrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep
 
 
 /**
- * @brief Construct a DQ_VrepRobot::DQ_VrepRobot object
+ * @brief Constructor of the DQ_VrepRobot class
  * 
  * @param robot_name The name of robot used on the vrep scene.
  * @param vrep_interface_sptr The DQ_VrepInterface smart pointer.

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
@@ -59,6 +59,11 @@ DQ_VrepRobot::DQ_VrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep
     vrep_interface_ = vrep_interface;
 }
 
+/**
+ * @brief Constructor of the class.
+ * @param robot_name The name of robot used on the vrep scene.
+ * @param vrep_interface_sptr The DQ_VrepInterface smart pointer.
+ */
 DQ_VrepRobot::DQ_VrepRobot(const std::string& robot_name, const std::shared_ptr<DQ_VrepInterface>& vrep_interface_sptr)
 {
     robot_name_ = robot_name;
@@ -67,11 +72,20 @@ DQ_VrepRobot::DQ_VrepRobot(const std::string& robot_name, const std::shared_ptr<
     vrep_interface_sptr_ = vrep_interface_sptr;
 }
 
+
+/**
+ * @brief _get_interface_ptr returns the DQ_VrepInterface raw pointer
+ * @returns The desired raw pointer.
+ */
 DQ_VrepInterface *DQ_VrepRobot::_get_interface_ptr() const
 {
     return vrep_interface_sptr_ ? vrep_interface_sptr_.get() : vrep_interface_;
 }
 
+/**
+ * @brief _get_interface_sptr returns the DQ_VrepInterface smart pointer
+ * @returns The desired smart pointer.
+ */
 std::shared_ptr<DQ_VrepInterface> DQ_VrepRobot::_get_interface_sptr() const
 {
     if(!vrep_interface_sptr_)

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
@@ -1,19 +1,25 @@
 /**
 (C) Copyright 2019-2023 DQ Robotics Developers
+
 This file is part of DQ Robotics.
+
     DQ Robotics is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
+
     DQ Robotics is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
+
     You should have received a copy of the GNU Lesser General Public License
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
+
 Contributors:
 - Murilo M. Marinho        (murilo@nml.t.u-tokyo.ac.jp)
         - Responsible for the original implementation.
+        
 - Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
         - Added smart pointers, deprecated raw pointers. 
          (Adapted from DQ_PseudoinverseController.h and DQ_KinematicController.h)

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepRobot.cpp
@@ -1,23 +1,22 @@
 /**
-(C) Copyright 2019 DQ Robotics Developers
-
+(C) Copyright 2019-2023 DQ Robotics Developers
 This file is part of DQ Robotics.
-
     DQ Robotics is free software: you can redistribute it and/or modify
     it under the terms of the GNU Lesser General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-
     DQ Robotics is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU Lesser General Public License for more details.
-
     You should have received a copy of the GNU Lesser General Public License
     along with DQ Robotics.  If not, see <http://www.gnu.org/licenses/>.
-
 Contributors:
 - Murilo M. Marinho        (murilo@nml.t.u-tokyo.ac.jp)
+        - Responsible for the original implementation.
+- Juan Jose Quiroz Omana   (juanjqo@g.ecc.u-tokyo.ac.jp)
+        - Added smart pointers, deprecated raw pointers. 
+         (Adapted from DQ_PseudoinverseController.h and DQ_KinematicController.h)
 */
 
 #include<dqrobotics/interfaces/vrep/DQ_VrepRobot.h>
@@ -53,4 +52,25 @@ DQ_VrepRobot::DQ_VrepRobot(const std::string& robot_name, DQ_VrepInterface* vrep
         throw std::runtime_error("Null reference to vrep_interface, initialize it first!");
     vrep_interface_ = vrep_interface;
 }
+
+DQ_VrepRobot::DQ_VrepRobot(const std::string& robot_name, const std::shared_ptr<DQ_VrepInterface>& vrep_interface_sptr)
+{
+    robot_name_ = robot_name;
+    if(!vrep_interface_sptr)
+        throw std::runtime_error("Null reference to vrep_interface, initialize it first!");
+    vrep_interface_sptr_ = vrep_interface_sptr;
+}
+
+DQ_VrepInterface *DQ_VrepRobot::_get_interface_ptr() const
+{
+    return vrep_interface_sptr_ ? vrep_interface_sptr_.get() : vrep_interface_;
+}
+
+std::shared_ptr<DQ_VrepInterface> DQ_VrepRobot::_get_interface_sptr() const
+{
+    if(!vrep_interface_sptr_)
+        throw std::runtime_error("DQ_VrepRobot::_get_interface_sptr invalid interface pointer");
+    return vrep_interface_sptr_;   
+}
+
 }

--- a/src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
@@ -36,11 +36,33 @@ LBR4pVrepRobot::LBR4pVrepRobot(const std::string& robot_name, DQ_VrepInterface* 
   _set_names(robot_name);
 }
 
+
+/**
+ * @brief Construct a new LBR4pVrepRobot::LBR4pVrepRobot object
+ * 
+ * @param robot_name The name of robot used on the vrep scene.
+ * @param vrep_interface_sptr The DQ_VrepInterface smart pointer.
+ * 
+ *               Example:
+ *               auto vi = std::make_shared<DQ_VrepInterface>(DQ_VrepInterface());
+ *               vi->connect(19997,100,5);
+ *               vi->start_simulation();
+ *               LBR4pVrepRobot lbr4p_vreprobot("LBR4p", vi);
+ *               auto q = lbr4p_vreprobot.get_q_from_vrep();
+ *               vi->stop_simulation();
+ *               vi->disconnect();
+ */
 LBR4pVrepRobot::LBR4pVrepRobot(const std::string& robot_name, const std::shared_ptr<DQ_VrepInterface>& vrep_interface_sptr): DQ_VrepRobot(robot_name, vrep_interface_sptr)
 {
   _set_names(robot_name);
 }
 
+
+/**
+ * @brief _set_names sets the joint_names_ and the base_frame_name_ attributes.
+ * 
+ * @param robot_name The name of robot used on the vrep scene.
+ */
 void LBR4pVrepRobot::_set_names(const std::string& robot_name)
 {
   std::vector<std::string> splited_name = strsplit(robot_name_,'#');

--- a/src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/robots/LBR4pVrepRobot.cpp
@@ -38,7 +38,7 @@ LBR4pVrepRobot::LBR4pVrepRobot(const std::string& robot_name, DQ_VrepInterface* 
 
 
 /**
- * @brief Construct a new LBR4pVrepRobot::LBR4pVrepRobot object
+ * @brief Constructor of the LBR4pVrepRobot class
  * 
  * @param robot_name The name of robot used on the vrep scene.
  * @param vrep_interface_sptr The DQ_VrepInterface smart pointer.

--- a/src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
@@ -41,7 +41,7 @@ YouBotVrepRobot::YouBotVrepRobot(const std::string& robot_name, DQ_VrepInterface
 
 
 /**
- * @brief Construct a new YouBotVrepRobot::YouBotVrepRobot object
+ * @brief Constructor of the YouBotVrepRobot class
  * 
  * @param robot_name The name of robot used on the vrep scene.
  * @param vrep_interface_sptr The DQ_VrepInterface smart pointer.

--- a/src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
+++ b/src/dqrobotics/interfaces/vrep/robots/YouBotVrepRobot.cpp
@@ -39,12 +39,34 @@ YouBotVrepRobot::YouBotVrepRobot(const std::string& robot_name, DQ_VrepInterface
     _set_names(robot_name);
 }
 
+
+/**
+ * @brief Construct a new YouBotVrepRobot::YouBotVrepRobot object
+ * 
+ * @param robot_name The name of robot used on the vrep scene.
+ * @param vrep_interface_sptr The DQ_VrepInterface smart pointer.
+ * 
+ *               Example:
+ *               auto vi = std::make_shared<DQ_VrepInterface>(DQ_VrepInterface());
+ *               vi->connect(19997,100,5);
+ *               vi->start_simulation();
+ *               YouBotVrepRobot youbot_vreprobot("youBot", vi);
+ *               auto q = youbot_vreprobot.get_q_from_vrep();
+ *               vi->stop_simulation();
+ *               vi->disconnect();
+ */
 YouBotVrepRobot::YouBotVrepRobot(const std::string& robot_name, const std::shared_ptr<DQ_VrepInterface>& vrep_interface_sptr):DQ_VrepRobot(robot_name, vrep_interface_sptr)
 {
     adjust_ = ((cos(pi/2) + i_*sin(pi/2)) * (cos(pi/4) + j_*sin(pi/4)))*(1+0.5*E_*-0.1*k_);
     _set_names(robot_name);
 }
 
+
+/**
+ * @brief _set_names sets the joint_names_ and the base_frame_name_ attributes.
+ * 
+ * @param robot_name The name of robot used on the vrep scene.
+ */
 void YouBotVrepRobot::_set_names(const std::string& robot_name)
 {
     std::vector<std::string> splited_name = strsplit(robot_name_,'#');


### PR DESCRIPTION
@dqrobotics/developers 

Hi @mmmarinho, 

this PR adds support for smart pointers. This feature was adapted from `DQ_PseudoinverseController.h` and `DQ_KinematicController.h`.

The current example that use `LBR4pVrepRobot` and `YouBotVrepRobot` (vrep_interface_move_kuka_and_youbot.cpp) is working. Furthermore, I tested a version using smart pointers ([vrep_interface_move_kuka_and_youbot_smart_pointers.zip](https://github.com/dqrobotics/cpp-interface-vrep/files/10379439/vrep_interface_move_kuka_and_youbot_smart_pointers.zip)).  I'm going to improve the documentation in a future PR.

Best regards, 

Juancho

![](https://img.shields.io/badge/Tests-developer%20workflow-orange)![](https://img.shields.io/badge/Ubuntu%2022.04%20LTS%20(x64)-passing-passing)![](https://img.shields.io/badge/MacOS%2013.1%20(ARM64)%20-passing-passing)![](https://img.shields.io/badge/Tested%20on-CoppeliaSim%204.4-blue)