### PR TITLE
[master-v4.5.1-rev4] Update the `CMakelists` to include `simConst.h` correctly.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_definitions(-DDO_NOT_USE_SHARED_MEMORY)
 
 INCLUDE_DIRECTORIES(${PROJECT_NAME} include)
 INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/remoteApi)
-INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/include)
+INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/include/simLib)
 
 ################################################################
 # DEFINE AND INSTALL LIBRARY AND INCLUDE FOLDER

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -26,7 +26,7 @@ Contributors:
 #include <dqrobotics/interfaces/vrep/DQ_VrepInterface.h>
 
 #include"extApi.h"
-#include"simLib/simConst.h"
+#include"simConst.h"
 
 #include<thread>
 #include<chrono>

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -26,7 +26,7 @@ Contributors:
 #include <dqrobotics/interfaces/vrep/DQ_VrepInterface.h>
 
 #include"extApi.h"
-#include"simConst.h"
+#include"simLib/simConst.h"
 
 #include<thread>
 #include<chrono>

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -1,5 +1,5 @@
 /**
-(C) Copyright 2019-2022 DQ Robotics Developers
+(C) Copyright 2019-2023 DQ Robotics Developers
 
 This file is part of DQ Robotics.
 


### PR DESCRIPTION
![](https://img.shields.io/badge/Tests-developer%20workflow-orange)![](https://img.shields.io/badge/Ubuntu%2020.04%20LTS%20(x64)-passing-passing)![](https://img.shields.io/badge/Tested%20on-CoppeliaSim%204.5.1-blue)
![](https://img.shields.io/badge/status-experimental-red)
@dqrobotics/developers 

Hi @mmmarinho, 

This PR updates the ~~submodules and~~ the ~~header~~ CMakelists in `DQ_VrepInterface()` to include `simConst.h`. 
On this branch, the synchronous mode is working properly on Ubuntu VM hosted on Windows, using CoppeliaSim 4.5.1.  I'm going to do more tests in different setups.

Context:
As discussed in [Python/pull51](https://github.com/dqrobotics/python/pull/51), the synchronous mode is not working as expected in the current version (bd2f2cc) of the `cpp-interface-vrep`.

Minimal example:

```cpp
#include <iostream>
#include <dqrobotics/interfaces/vrep/DQ_VrepInterface.h>
#include <thread>

int main()
{
    auto vi = DQ_VrepInterface();
    try {
        if (!vi.connect("10.198.113.136", 19997,100,10))
            throw std::runtime_error("Unable to connect to CoppeliaSim.");
        vi.set_synchronous(true);
        vi.start_simulation();
        std::this_thread::sleep_for(std::chrono::milliseconds(100));
        //---------------Your code here----------------------------

        double time_simulation_step = 0.05;
        double y_0 = vi.get_object_pose("/Sphere").translation().vec3()[2];
        double y_sim;
        double y_est;
        double t;
        std::cout<<"-----------------"<<std::endl;
        std::cout<<"Initial height: "<<y_0<<std::endl;
        std::cout<<"-----------------"<<std::endl;

        for (int i=0; i<=5; i++)
        {
            t = i*time_simulation_step;
            y_sim = vi.get_object_pose("/Sphere").translation().vec3()[2];
            y_est = y_0 - 0.5 * 9.81 * std::pow(t, 2);
            vi.trigger_next_simulation_step();
            vi.wait_for_simulation_step_to_end();
        }
        std::cout<<"Elapsed time: "<<t<<std::endl;
        std::cout<<"Estimated height: "<<y_est<<", Measured height: "<<y_sim<<std::endl;
        vi.stop_simulation();
        vi.disconnect();
    } catch (std::exception& e) {
        std::cout<<e.what()<<std::endl;
        vi.stop_simulation();
        vi.disconnect();
    }
    return 0;
}

Output

```shell
Estimated height: 0.693437, Measured height: 0.687306
```

Best regards, 

Juancho

