### PR TITLE
This PR fix the head position of the submodule remoteApi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_definitions(-DDO_NOT_USE_SHARED_MEMORY)
 
 INCLUDE_DIRECTORIES(${PROJECT_NAME} include)
 INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/remoteApi)
-INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/include/simLib)
+INCLUDE_DIRECTORIES(${PROJECT_NAME} coppeliarobotics/include)
 
 ################################################################
 # DEFINE AND INSTALL LIBRARY AND INCLUDE FOLDER

--- a/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
+++ b/src/dqrobotics/interfaces/vrep/DQ_VrepInterface.cpp
@@ -26,7 +26,7 @@ Contributors:
 #include <dqrobotics/interfaces/vrep/DQ_VrepInterface.h>
 
 #include"extApi.h"
-#include"simConst.h"
+#include"simLib/simConst.h"
 
 #include<thread>
 #include<chrono>


### PR DESCRIPTION
![](https://img.shields.io/badge/Tests-developer%20workflow-orange)![](https://img.shields.io/badge/Ubuntu%2020.04%20LTS%20(x64)-passing-passing)![](https://img.shields.io/badge/Tested%20on-CoppeliaSim%204.5.1-blue)
![](https://img.shields.io/badge/status-experimental-red)

@dqrobotics/developers 

Hi @mmmarinho, I realized that the head position of the submodule `remoteAPI` is different from the one it is supposed to be (coppeliasim-v4.5.1-rev4, 801a840). 

This PR sets the head position of the `remoteAPI` submodule from 93f6af5 to coppeliasim-v4.5.1-rev4 (801a840) and implements the corresponding modifications in DQ_VrepInterface() and CMakeLists.
I believe this could fix the current error in the [PPA](https://code.launchpad.net/~dqrobotics-dev/+recipe/dqrobotics-interface-vrep-dev-v4.5.1-rev4).


| submodule | tag | head | current head in master-v4.5.1-rev4| is right?|
| ------------- | ------------- |------------- |------------- |------------- |
| remoteAPI | coppeliasim-v4.5.1-rev4  | 801a840 | 93f6af5 |:x: |
| include  | coppeliasim-v4.5.1-rev4  | 0e9eeb4 | 0e9eeb4  | :white_check_mark: |

Best regards, 

Juancho